### PR TITLE
Be tolerant of timeout errors

### DIFF
--- a/pkg/atomix/election/election.go
+++ b/pkg/atomix/election/election.go
@@ -227,7 +227,9 @@ func (e *election) Watch(ctx context.Context, ch chan<- Event) error {
 		}()
 		for {
 			response, err := stream.Recv()
-			if err == io.EOF || err == context.Canceled || errors.IsCanceled(errors.From(err)) {
+			if err == io.EOF ||
+				errors.IsCanceled(errors.From(err)) ||
+				errors.IsTimeout(errors.From(err)) {
 				return
 			} else if err != nil {
 				log.Errorf("Watch failed: %v", err)

--- a/pkg/atomix/indexedmap/indexedmap.go
+++ b/pkg/atomix/indexedmap/indexedmap.go
@@ -513,7 +513,9 @@ func (m *indexedMap) Watch(ctx context.Context, ch chan<- Event, opts ...WatchOp
 		}()
 		for {
 			response, err := stream.Recv()
-			if err == io.EOF || err == context.Canceled || errors.IsCanceled(errors.From(err)) {
+			if err == io.EOF ||
+				errors.IsCanceled(errors.From(err)) ||
+				errors.IsTimeout(errors.From(err)) {
 				return
 			} else if err != nil {
 				log.Errorf("Watch failed: %v", err)

--- a/pkg/atomix/list/list.go
+++ b/pkg/atomix/list/list.go
@@ -263,7 +263,9 @@ func (l *list) Watch(ctx context.Context, ch chan<- Event, opts ...WatchOption) 
 		}()
 		for {
 			response, err := stream.Recv()
-			if err == io.EOF || err == context.Canceled || errors.IsCanceled(errors.From(err)) {
+			if err == io.EOF ||
+				errors.IsCanceled(errors.From(err)) ||
+				errors.IsTimeout(errors.From(err)) {
 				return
 			} else if err != nil {
 				log.Errorf("Watch failed: %v", err)

--- a/pkg/atomix/map/map.go
+++ b/pkg/atomix/map/map.go
@@ -285,7 +285,9 @@ func (m *_map) Watch(ctx context.Context, ch chan<- Event, opts ...WatchOption) 
 		}()
 		for {
 			response, err := stream.Recv()
-			if err == io.EOF || err == context.Canceled || errors.IsCanceled(errors.From(err)) {
+			if err == io.EOF ||
+				errors.IsCanceled(errors.From(err)) ||
+				errors.IsTimeout(errors.From(err)) {
 				return
 			} else if err != nil {
 				log.Errorf("Watch failed: %v", err)

--- a/pkg/atomix/set/set.go
+++ b/pkg/atomix/set/set.go
@@ -235,7 +235,9 @@ func (s *set) Watch(ctx context.Context, ch chan<- Event, opts ...WatchOption) e
 		}()
 		for {
 			response, err := stream.Recv()
-			if err == io.EOF || err == context.Canceled || errors.IsCanceled(errors.From(err)) {
+			if err == io.EOF ||
+				errors.IsCanceled(errors.From(err)) ||
+				errors.IsTimeout(errors.From(err)) {
 				return
 			} else if err != nil {
 				log.Errorf("Watch failed: %v", err)

--- a/pkg/atomix/value/value.go
+++ b/pkg/atomix/value/value.go
@@ -147,7 +147,9 @@ func (v *value) Watch(ctx context.Context, ch chan<- Event) error {
 		}()
 		for {
 			response, err := stream.Recv()
-			if err == io.EOF || err == context.Canceled || errors.IsCanceled(errors.From(err)) {
+			if err == io.EOF ||
+				errors.IsCanceled(errors.From(err)) ||
+				errors.IsTimeout(errors.From(err)) {
 				return
 			} else if err != nil {
 				log.Errorf("Watch failed: %v", err)


### PR DESCRIPTION
This PR makes the client side Watch tolerant of timeout errors. Timeouts are causing intermittent failures during sdran testing.